### PR TITLE
fix: unlocked access to vNodes.size() + avoid possible confusions in CPubKey 

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -82,8 +82,8 @@ public:
     }
 
     // Construct a public key from a byte vector.
-    CPubKey(const std::vector<unsigned char> &vch) {
-        Set(vch.begin(), vch.end());
+    CPubKey(const std::vector<unsigned char> &vecChr) {
+        Set(vecChr.begin(), vecChr.end());
     }
 
     // Simple read-only vector-like interface to the pubkey data.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -818,8 +818,13 @@ void ThreadSocketHandler()
                 }
             }
         }
-        if(vNodes.size() != nPrevNodeCount) {
-            nPrevNodeCount = vNodes.size();
+        size_t vNodesSize;
+        {
+             LOCK(cs_vNodes);
+             vNodesSize = vNodes.size();
+        }
+        if(vNodesSize != nPrevNodeCount) {
+            nPrevNodeCount = vNodesSize;
             uiInterface.NotifyNumConnectionsChanged(nPrevNodeCount);
         }
 


### PR DESCRIPTION
follows Bitcoin 0.14.2: https://github.com/bitcoin/bitcoin/commit/dfed983f19e7b61da243362f00fa3a14c92dae45