### PR TITLE
usability: show IP when calling getinfo

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -45,6 +45,7 @@ Value getinfo(const Array& params, bool fHelp)
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
             "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
+	    "  \"ip\": xxxxx,                (string) local ip address\n"
             "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
             "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
             "  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
@@ -77,6 +78,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string())));
+    obj.push_back(Pair("ip",            GetLocalAddress(NULL).ToStringIP()));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       TestNet()));
 #ifdef ENABLE_WALLET
@@ -406,4 +408,4 @@ Value makekeypair(const Array& params, bool fHelp)
     result.push_back(Pair("PublicKey", pubkeyhex));
     result.push_back(Pair("PrivateKey", CBitcoinSecret(key).ToString()));
     return result;
-}
+} 


### PR DESCRIPTION
Show IP address of the local machine when calling getinfo. This information is very much needed when setting up masternodes, for example.

![show_ip](https://img3.picload.org/image/rwrlidpr/getinfo.png)