### PR TITLE
fix: length not updated in DecodeBase58

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -47,7 +47,7 @@ bool DecodeBase58(const char *psz, std::vector<unsigned char>& vch) {
             carry /= 256;
         }
         assert(carry == 0);
-	length = 0;
+	length = i;
         psz++;
     }
     // Skip trailing spaces.


### PR DESCRIPTION
The variable length must be updated because we need it later when copying the results.

User **cryptopanda** from our Slack pointed me to a problem in DecodeBase58.