### PR TITLE
masternode fixes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -452,16 +452,18 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool darkSendMaste
     if (pszDest == NULL) {
         if (IsLocal(addrConnect))
             return NULL;
-
+		
+        LOCK(cs_vNodes);
         // Look for an existing connection
         CNode* pnode = FindNode((CService)addrConnect);
         if (pnode)
         {
-            pnode->AddRef();
-
-            if(darkSendMaster)
+            // we have connection to this node but not as masternode
+            // change flag & add reference so we can clear it later
+            if(darkSendMaster && !pnode->fDarkSendMaster) {
+                pnode->AddRef();
                 pnode->fDarkSendMaster = true;
-
+            }
             return pnode;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1323,7 +1323,7 @@ void ThreadOpenConnections()
         {
             LOCK(cs_vNodes);
             BOOST_FOREACH(CNode* pnode, vNodes) {
-                if (!pnode->fInbound) {
+                if (!pnode->fInbound && !pnode->fDarkSendMaster) {
                     setConnected.insert(pnode->addr.GetGroup());
                     nOutbound++;
                 }


### PR DESCRIPTION
* **do not use masternode connections in feeler logic**

Following a similar fix from Dash: https://github.com/dashpay/dash/pull/1533
Only variable name was different, **fDarkSendMaster** instead of **fMasternode**.

* **potential deadlock & set reference after check for mastenode flag**

Found by reading Dash's implementation of [net.cpp](https://github.com/OlegGirko/dash/blob/b96f70e696530fad4a2a00f882e8d4ff44d1ae5b/src/net.cpp#L398)