### PR TITLE
Set CXX std to c++11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,7 @@ fi
 ##       compatibility with the legacy buildsystem.
 ##
 if test "x$CXXFLAGS_overridden" = "xno"; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -std=c++11 -DBOOST_NO_CXX11_SCOPED_ENUMS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter"
 fi
 CPPFLAGS="$CPPFLAGS -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 


### PR DESCRIPTION
- Set CXX std to c++11 needed for merging code from Bitcoin 0.14
- Define BOOST_NO_CXX11_SCOPED_ENUMS for boost compatibility
