### PR TITLE
updated Script, Makefile, Conversion fixes & Hash functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,8 @@ BITCOIN_CORE_H = \
   addrman.h \
   alert.h \
   allocators.h \
-  base58.h bignum.h \
+  base58.h \
+  bignum.h \
   bloom.h \
   chainparams.h \
   checkpoints.h \
@@ -65,20 +66,22 @@ BITCOIN_CORE_H = \
   rpcclient.h \
   rpcprotocol.h \
   rpcserver.h \
-  script.h \
+  script/script.h \
   serialize.h \
-  sph_blake.h \
-  sph_bmw.h \
-  sph_cubehash.h \
-  sph_echo.h \
-  sph_groestl.h \
-  sph_jh.h \
-  sph_keccak.h \
-  sph_luffa.h \
-  sph_shavite.h \
-  sph_simd.h \
-  sph_skein.h \
-  sph_types.h \
+  crypto/sha256.h \
+  crypto/hmac_sha256.h \
+  crypto/sph_blake.h \
+  crypto/sph_bmw.h \
+  crypto/sph_cubehash.h \
+  crypto/sph_echo.h \
+  crypto/sph_groestl.h \
+  crypto/sph_jh.h \
+  crypto/sph_keccak.h \
+  crypto/sph_luffa.h \
+  crypto/sph_shavite.h \
+  crypto/sph_simd.h \
+  crypto/sph_skein.h \
+  crypto/sph_types.h \
   spork.h \
   sync.h \
   threadsafety.h \
@@ -86,9 +89,9 @@ BITCOIN_CORE_H = \
   compat/byteswap.h \
   compat/endian.h \
   torcontrol.h \
-  hmac_sha256.h \
-  sha256.h \
-  common.h \
+  crypto/hmac_sha256.h \
+  crypto/sha256.h \
+  crypto/common.h \
   txdb.h \
   txmempool.h \
   ui_interface.h \
@@ -165,32 +168,32 @@ libchaincoin_common_a_SOURCES = \
   masternodeman.cpp \
   masternodeconfig.cpp \
   torcontrol.cpp \
-  hmac_sha256.cpp \
-  sha256.cpp \
+  crypto/hmac_sha256.cpp \
+  crypto/sha256.cpp \
   instantx.cpp \
   hash.cpp \
   key.cpp \
   netbase.cpp \
   protocol.cpp \
   rpcprotocol.cpp \
-  script.cpp \
+  script/script.cpp \
   sync.cpp \
   util.cpp \
   random.cpp \
   version.cpp \
-  aes_helper.c \
-  luffa.c \
-  groestl.c \
-  jh.c \
-  echo.c \
-  shavite.c \
-  keccak.c \
-  skein.c \
+  crypto/aes_helper.c \
+  crypto/luffa.c \
+  crypto/groestl.c \
+  crypto/jh.c \
+  crypto/echo.c \
+  crypto/shavite.c \
+  crypto/keccak.c \
+  crypto/skein.c \
   spork.cpp \
-  bmw.c \
-  simd.c \
-  cubehash.c \
-  blake.c \
+  crypto/bmw.c \
+  crypto/simd.c \
+  crypto/cubehash.c \
+  crypto/blake.c \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT

--- a/src/hash.h
+++ b/src/hash.h
@@ -22,6 +22,7 @@
 #include "sph_shavite.h"
 #include "sph_simd.h"
 #include "sph_echo.h"
+#include "prevector.h"
 
 #include <vector>
 
@@ -172,7 +173,15 @@ inline uint160 Hash160(const T1 pbegin, const T1 pend)
     return hash2;
 }
 
+/** Compute the 160-bit hash of a vector. */
 inline uint160 Hash160(const std::vector<unsigned char>& vch)
+{
+    return Hash160(vch.begin(), vch.end());
+}
+
+/** Compute the 160-bit hash of a vector. */
+template<unsigned int N>
+inline uint160 Hash160(const prevector<N, unsigned char>& vch)
 {
     return Hash160(vch.begin(), vch.end());
 }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -1,11 +1,17 @@
+// Copyright (c) 2015-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef _BITCOIN_PREVECTOR_H_
 #define _BITCOIN_PREVECTOR_H_
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 
 #include <iterator>
+#include <type_traits>
 
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
@@ -126,7 +132,7 @@ public:
         typedef const T* pointer;
         typedef const T& reference;
         typedef std::bidirectional_iterator_tag iterator_category;
-        const_reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(const T* ptr_) : ptr(ptr_) {}
         const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
         const T& operator*() const { return *ptr; }
         const T* operator->() const { return ptr; }
@@ -166,10 +172,15 @@ private:
             }
         } else {
             if (!is_direct()) {
+                /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
+                    success. These should instead use an allocator or new/delete so that handlers
+                    are called as necessary, but performance would be slightly degraded by doing so. */
                 _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
+                assert(_union.indirect);
                 _union.capacity = new_capacity;
             } else {
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
                 memcpy(dst, src, size() * sizeof(T));
@@ -209,7 +220,7 @@ public:
         }
     }
 
-    prevector() : _size(0) {}
+    prevector() : _size(0), _union{{}} {}
 
     explicit prevector(size_type n) : _size(0) {
         resize(n);
@@ -244,6 +255,10 @@ public:
         }
     }
 
+    prevector(prevector<N, T, Size, Diff>&& other) : _size(0) {
+        swap(other);
+    }
+
     prevector& operator=(const prevector<N, T, Size, Diff>& other) {
         if (&other == this) {
             return *this;
@@ -256,6 +271,11 @@ public:
             new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
             ++it;
         }
+        return *this;
+    }
+
+    prevector& operator=(prevector<N, T, Size, Diff>&& other) {
+        swap(other);
         return *this;
     }
 
@@ -367,12 +387,22 @@ public:
     }
 
     iterator erase(iterator first, iterator last) {
+        // Erase is not allowed to the change the object's capacity. That means
+        // that when starting with an indirectly allocated prevector with
+        // size and capacity > N, the result may be a still indirectly allocated
+        // prevector with size <= N and capacity > N. A shrink_to_fit() call is
+        // necessary to switch to the (more efficient) directly allocated
+        // representation (with capacity N and size <= N).
         iterator p = first;
         char* endp = (char*)&(*end());
-        while (p != last) {
-            (*p).~T();
-            _size--;
-            ++p;
+        if (!std::is_trivially_destructible<T>::value) {
+            while (p != last) {
+                (*p).~T();
+                _size--;
+                ++p;
+            }
+        } else {
+            _size -= last - p;
         }
         memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
@@ -413,7 +443,9 @@ public:
     }
 
     ~prevector() {
-        clear();
+        if (!std::is_trivially_destructible<T>::value) {
+            clear();
+        }
         if (!is_direct()) {
             free(_union.indirect);
             _union.indirect = NULL;
@@ -470,6 +502,14 @@ public:
         } else {
             return ((size_t)(sizeof(T))) * _union.capacity;
         }
+    }
+
+    value_type* data() {
+        return item_ptr(0);
+    }
+
+    const value_type* data() const {
+        return item_ptr(0);
     }
 };
 #pragma pack(pop)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -1743,7 +1743,8 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CTransa
         bool fSolved =
             Solver(keystore, subscript, hash2, nHashType, txin.scriptSig, subType) && subType != TX_SCRIPTHASH;
         // Append serialized subscript whether or not it is completely signed:
-        txin.scriptSig << static_cast<valtype>(subscript);
+        // txin.scriptSig << static_cast<valtype>(subscript);
+        txin.scriptSig << valtype(subscript.begin(), subscript.end());
         if (!fSolved) return false;
     }
 
@@ -1935,10 +1936,10 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
 bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:
-    return (this->size() == 23 &&
-            this->at(0) == OP_HASH160 &&
-            this->at(1) == 0x14 &&
-            this->at(22) == OP_EQUAL);
+     return (this->size() == 23 &&
+            (*this)[0] == OP_HASH160 &&
+            (*this)[1] == 0x14 &&
+            (*this)[22] == OP_EQUAL);
 }
 
 bool CScript::IsPushOnly() const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include <stdint.h>
+#include <string.h>
 #include <string>
 #include <vector>
 
@@ -409,6 +410,10 @@ protected:
         {
             push_back(n + (OP_1 - 1));
         }
+        else if (n == 0)
+        {
+            push_back(OP_0);
+        }
         else
         {
             *this << CScriptNum::serialize(n);
@@ -417,7 +422,6 @@ protected:
     }
 public:
     CScript() { }
-    CScript(const CScript& b) : CScriptBase(b.begin(), b.end()) { }
     CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
@@ -682,7 +686,8 @@ public:
     void clear()
     {
         // The default std::vector::clear() does not release memory.
-        CScriptBase().swap(*this);
+        CScriptBase::clear();
+        shrink_to_fit();
     }
 
     void SetDestination(const CTxDestination& address);


### PR DESCRIPTION
* Updated several paths to crypto sources in Makefile.am 
* Fixed a potential path issue with base58/bignum in Makefile.am
* Fixed problem with CScript conversion with a new template function in hash.h
* Fixed indexing issue in *CScript::IsPayToScriptHash()*
* Expanded *CScript::push_int64(int64_t n)* to check for **OP_0**
* New implementation of CScript::clear() that follows Bitcoin.
* Replaced *static_cast* of serialization in *SignSignature* with a range based version. 