### PR TITLE
move rotated debug-logs into separate directory

### DIFF
--- a/src/chaincoind.cpp
+++ b/src/chaincoind.cpp
@@ -45,7 +45,7 @@ void DetectShutdownThread(boost::thread_group* threadGroup)
     }
     if (threadGroup)
     {
-        threadGroup->interrupt_all();
+        Interrupt(*threadGroup);
         threadGroup->join_all();
     }
 }
@@ -166,20 +166,14 @@ bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
-        if (detectShutdownThread)
-            detectShutdownThread->interrupt();
-
-        threadGroup.interrupt_all();
+        Interrupt(threadGroup);
         // threadGroup.join_all(); was left out intentionally here, because we didn't re-test all of
         // the startup-failure cases to make sure they don't result in a hang due to some
         // thread-blocking-waiting-for-another-thread-during-startup case
-    }
-
-    if (detectShutdownThread)
-    {
+    } else {
         detectShutdownThread->join();
         delete detectShutdownThread;
-        detectShutdownThread = NULL;
+        detectShutdownThread = NULL;	
     }
     Shutdown();
 

--- a/src/init.h
+++ b/src/init.h
@@ -19,7 +19,10 @@ extern CWallet* pwalletMain;
 
 void StartShutdown();
 bool ShutdownRequested();
+void PrepareShutdown();
 void Shutdown();
+/** Interrupt threads */
+void Interrupt(boost::thread_group& threadGroup);
 bool AppInit2(boost::thread_group& threadGroup);
 
 /* The help message mode determines what help message to show */

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -40,6 +40,7 @@ static ssl::context* rpc_ssl_context = NULL;
 static boost::thread_group* rpc_worker_group = NULL;
 static boost::asio::io_service::work *rpc_dummy_work = NULL;
 static std::vector< boost::shared_ptr<ip::tcp::acceptor> > rpc_acceptors;
+static bool fRPCRunning = false;
 
 void RPCTypeCheck(const Array& params,
                   const list<Value_type>& typesExpected,
@@ -589,6 +590,7 @@ void StartRPCThreads()
 
         rpc_acceptors.push_back(acceptor);
         fListening = true;
+        fRPCRunning = true;
     }
     catch(boost::system::system_error &e)
     {
@@ -640,6 +642,18 @@ void StartDummyRPCThread()
         rpc_worker_group = new boost::thread_group();
         rpc_worker_group->create_thread(boost::bind(&asio::io_service::run, rpc_io_service));
     }
+}
+
+void InterruptRPC()
+{
+    LogPrint("rpc", "Interrupting RPC\n");
+    // Interrupt e.g. running longpolls
+    fRPCRunning = false;
+}
+
+bool IsRPCRunning()
+{
+    return fRPCRunning;
 }
 
 void StopRPCThreads()

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -29,6 +29,9 @@ void StartRPCThreads();
 void StartDummyRPCThread();
 /* Stop RPC threads */
 void StopRPCThreads();
+void InterruptRPC();
+/** Query whether RPC is running */
+bool IsRPCRunning();
 
 /*
   Type-check arguments; throws JSONRPCError if wrong type given. Does not check that


### PR DESCRIPTION
The current log rotation leaves many old logfiles in the *.chaincoin* directory that [some users](https://github.com/chaincoin/chaincoin/issues/55) don't like. A workaround for Linux/Mac systems via cronjobs exists but there's no clean solution for Windows.

This patch introduces **moving** of old logfiles to a **separate** *logs* **sub directory** within *.chaincoin*.